### PR TITLE
fix window sizing issue when running :RegisterEdit from a very small window

### DIFF
--- a/lua/internals.lua
+++ b/lua/internals.lua
@@ -46,9 +46,32 @@ local function open_editor_window(reg)
     local buf_lines = reg_content:split("\n")
     local window_height = #buf_lines
 
+    -- keep track of existing equalalways setting, and set equalalways to
+    -- false. See https://github.com/tuurep/registereditor/issues/1 for
+    -- details.
+    local old_equalalways = vim.o.equalalways
+    vim.o.equalalways = false
+
+    -- get information about old window
+    local old_window_id = vim.fn.win_getid()
+    local old_window_height = vim.api.nvim_win_get_height(old_window_id)
+
+    -- make sure the old window is big enough to split
+    vim.api.nvim_win_set_height(old_window_id, old_window_height + 2)
+
+    -- open the new window
     vim.cmd("below " .. window_height .. "new @\\" .. reg)
 
+    -- return the old window to its previous size
+    vim.api.nvim_win_set_height(old_window_id, old_window_height)
+
+    -- resize the new window back to its proper size.
+    vim.api.nvim_win_set_height(0, window_height)
+
     vim.wo.winfixheight = true
+
+    -- restore the original equalalways setting
+    vim.o.equalalways = old_equalalways
 
     -- Scratch buffer settings
     vim.bo.bufhidden = "wipe"

--- a/lua/internals.lua
+++ b/lua/internals.lua
@@ -1,5 +1,9 @@
 local M = {}
 
+-- maximum height of a registereditor window. This can become a configurable
+-- option in the future
+local MAX_BUFFER_LINES = 20
+
 -- https://stackoverflow.com/questions/72386387/lua-split-string-to-table
 -- Split string into table on newlines, include empty lines (\n\n\n)
 function string:split(sep)
@@ -44,7 +48,7 @@ local function open_editor_window(reg)
     end
 
     local buf_lines = reg_content:split("\n")
-    local window_height = #buf_lines
+    local window_height = math.min(#buf_lines, MAX_BUFFER_LINES)
 
     -- keep track of existing equalalways setting, and set equalalways to
     -- false. See https://github.com/tuurep/registereditor/issues/1 for


### PR DESCRIPTION
Closes #1

In order to preserve the layout of existing windows, it makes sense to turn off `equalalways` while messing with the window splits. Afterwards, we can turn it back on if it was on before.

In order to make sure there is actually enough room to split the new window, we have to slightly enlarge the previous window first when `equalalways` is off.

## TODO list

- [x] Resize windows properly in most cases
- [x] Be compatible with global `equalalways` and `noequalalways` options.
- [x] Institute a maximum buffer height.