### PR TITLE
Add a user command to close registereditor windows

### DIFF
--- a/lua/internals.lua
+++ b/lua/internals.lua
@@ -17,6 +17,11 @@ function string:split(sep)
     return result
 end
 
+local function split_first_token(value)
+    local first, rest = value:match("^(%S+)%s*(.*)")
+    return { first = first, rest = rest }
+end
+
 local function set_register(reg)
     vim.fn.setreg(reg, "")
 
@@ -119,7 +124,7 @@ local function parse_register_list(arg)
     return registers
 end
 
-M.open_all_windows = function(arg)
+local function open_all_windows(arg)
     -- check all args and build table
     local registers = parse_register_list(arg)
     if #registers == 0 then
@@ -160,7 +165,7 @@ local function close_buffer(buffer)
     vim.cmd("bd " .. buffer)
 end
 
-M.close_windows = function(arg)
+local function close_windows(arg)
     -- see what registers were specified. If there were none, then registers
     -- will be nil
     local registers = nil
@@ -192,6 +197,21 @@ M.close_windows = function(arg)
             end
         end
     end)
+end
+
+-- main entry point for the :RegisterEdit user command
+M.register_edit_command = function(arg)
+    -- split the first argument from the rest of the arguments
+    local split_result = split_first_token(arg)
+
+    -- check if the first argument is an action
+    if split_result.first == "open" then
+        open_all_windows(split_result.rest)
+    elseif split_result.first == "close" then
+        close_windows(split_result.rest)
+    else
+        open_all_windows(arg)
+    end
 end
 
 return M

--- a/lua/internals.lua
+++ b/lua/internals.lua
@@ -199,8 +199,8 @@ local function close_windows(arg)
     end)
 end
 
--- main entry point for the :RegisterEdit user command
-M.register_edit_command = function(arg)
+-- main entry point for the :RegisterEditor user command
+M.registereditor_command = function(arg)
     -- split the first argument from the rest of the arguments
     local split_result = split_first_token(arg)
 

--- a/lua/internals.lua
+++ b/lua/internals.lua
@@ -173,28 +173,20 @@ local function close_windows(arg)
         registers = parse_register_list(arg)
     end
 
-    -- loop over all the buffers and close the appropriate ones.
+    -- loop over all the buffers and close the appropriate ones
     loop_over_register_buffers(function(buffer)
-        -- if the registers list is nil or empty, then close all the buffers
-        if registers == nil or #registers == 0 then
+        -- find out what register the buffer corresponds to
+        local buffer_register = get_register_from_buffer(buffer)
+
+        -- determine if the buffer should be closed based on the supplied
+        -- list of registers. If the registers list is nil or empty, then
+        -- always close the buffer
+        if
+            registers == nil
+            or #registers == 0
+            or vim.tbl_contains(registers, buffer_register)
+        then
             close_buffer(buffer)
-        else
-            -- find out what register the buffer corresponds to
-            local buffer_register = get_register_from_buffer(buffer)
-
-            -- determine if the buffer should be closed based on the supplied
-            -- list of registers
-            local should_close = false
-            for _, register in pairs(registers) do
-                if register == buffer_register then
-                    should_close = true
-                end
-            end
-
-            -- close the buffer if necessary
-            if should_close then
-                close_buffer(buffer)
-            end
         end
     end)
 end

--- a/lua/internals.lua
+++ b/lua/internals.lua
@@ -78,6 +78,7 @@ local function open_editor_window(reg)
     vim.o.equalalways = old_equalalways
 
     -- Scratch buffer settings
+    vim.bo.filetype = "registereditor"
     vim.bo.bufhidden = "wipe"
     vim.bo.swapfile = false
     vim.bo.buflisted = false

--- a/lua/internals.lua
+++ b/lua/internals.lua
@@ -127,7 +127,7 @@ end
 local function open_all_windows(arg)
     -- check all args and build table
     local registers = parse_register_list(arg)
-    if #registers == 0 then
+    if registers == nil or #registers == 0 then
         return
     end
 

--- a/plugin/registereditor.lua
+++ b/plugin/registereditor.lua
@@ -2,12 +2,8 @@ local internals = require("internals")
 
 local function setup_user_commands()
     vim.api.nvim_create_user_command("RegisterEdit", function(opts)
-        internals.open_all_windows(opts.args)
+        internals.register_edit_command(opts.args)
     end, { nargs = "+" })
-
-    vim.api.nvim_create_user_command("RegisterEditClose", function(opts)
-        internals.close_windows(opts.args)
-    end, { nargs = "*" })
 end
 
 setup_user_commands()

--- a/plugin/registereditor.lua
+++ b/plugin/registereditor.lua
@@ -1,8 +1,8 @@
 local internals = require("internals")
 
 local function setup_user_commands()
-    vim.api.nvim_create_user_command("RegisterEdit", function(opts)
-        internals.register_edit_command(opts.args)
+    vim.api.nvim_create_user_command("RegisterEditor", function(opts)
+        internals.registereditor_command(opts.args)
     end, { nargs = "+" })
 end
 

--- a/plugin/registereditor.lua
+++ b/plugin/registereditor.lua
@@ -4,6 +4,10 @@ local function setup_user_commands()
     vim.api.nvim_create_user_command("RegisterEdit", function(opts)
         internals.open_all_windows(opts.args)
     end, { nargs = "+" })
+
+    vim.api.nvim_create_user_command("RegisterEditClose", function(opts)
+        internals.close_windows(opts.args)
+    end, { nargs = "*" })
 end
 
 setup_user_commands()


### PR DESCRIPTION
The command is `:RegisterEditClose`. With no arguments, it closes all the registereditor buffers. Optionally, you can specify one or more registers and all corresponding registereditor buffers will be closed.

For instance, `:RegisterEdit a a a b c a` followed by `:RegisterEditClose a` would leave you with only 2 registereditor windows open (one for `b` and one for `c`).